### PR TITLE
Change outdated implementations for Comic Meteor and Comic Polaris

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -86,7 +86,8 @@ export const ValidProxiedHosts = union([
     "i.pximg.net",
     "api.pocket.shonenmagazine.com",
     "mgpk-cdn.magazinepocket.com",
-    "kirapo.jp"
+    "kirapo.jp",
+    "cdn-ak-img.shonenjumpplus.com"
   ]),
   pattern(string(), /[^\/]*\.cloudfront\.net/)
 ])

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -43,8 +43,6 @@ export const ValidProxiedHosts = union([
     'comic-trail.com',
     'cdn-img.comic-trail.com',
     'www.comic-brise.com',
-    'comic-meteor.jp',
-    'comic-polaris.jp',
     'manga.zerosumonline.com',
     'gammaplus.takeshobo.co.jp',
     'gaugau.futabanet.jp',
@@ -87,7 +85,8 @@ export const ValidProxiedHosts = union([
     "www.pixiv.net",
     "i.pximg.net",
     "api.pocket.shonenmagazine.com",
-    "mgpk-cdn.magazinepocket.com"
+    "mgpk-cdn.magazinepocket.com",
+    "kirapo.jp"
   ]),
   pattern(string(), /[^\/]*\.cloudfront\.net/)
 ])

--- a/src/resources/Kirapo.ts
+++ b/src/resources/Kirapo.ts
@@ -1,13 +1,13 @@
 import SpeedBinbHandler from "./SpeedBinb";
 
 export default class KirapoHandler extends SpeedBinbHandler {
-  get_ptimg_url(ptimg_url: string): string {
-    const base_url = this.url.href.replace(/viewer$/, '')
-    return `${base_url}/${ptimg_url}`
+  getPtimgUrl(ptimgUrl: string): string {
+    const baseUrl = this.url.href.replace(/viewer$/, '')
+    return `${baseUrl}/${ptimgUrl}`
   }
 
-  get_img_url(src_url: string): string {
-    const base_url = this.url.href.replace(/viewer$/, '')
-    return `${base_url}/data/${src_url}`
+  getImgUrl(srcUrl: string): string {
+    const baseUrl = this.url.href.replace(/viewer$/, '')
+    return `${baseUrl}/data/${srcUrl}`
   }
 }

--- a/src/resources/Kirapo.ts
+++ b/src/resources/Kirapo.ts
@@ -1,0 +1,13 @@
+import SpeedBinbHandler from "./SpeedBinb";
+
+export default class KirapoHandler extends SpeedBinbHandler {
+  get_ptimg_url(ptimg_url: string): string {
+    const base_url = this.url.href.replace(/viewer$/, '')
+    return `${base_url}/${ptimg_url}`
+  }
+
+  get_img_url(src_url: string): string {
+    const base_url = this.url.href.replace(/viewer$/, '')
+    return `${base_url}/data/${src_url}`
+  }
+}

--- a/src/resources/SpeedBinb.ts
+++ b/src/resources/SpeedBinb.ts
@@ -38,12 +38,12 @@ export default class SpeedBinbHandler implements ResourceHandler {
     this.zipFile = new JSZip()
   }
 
-  get_ptimg_url(ptimg_url: string): string {
-    return `${this.url.href}/${ptimg_url}`
+  getPtimgUrl(ptimgUrl: string): string {
+    return `${this.url.href}/${ptimgUrl}`
   }
 
-  get_img_url(src_url: string): string {
-    return `${this.url.href}/data/${src_url}`
+  getImgUrl(srcUrl: string): string {
+    return `${this.url.href}/data/${srcUrl}`
   }
 
   async execute(): Promise<JSZip> {
@@ -60,8 +60,8 @@ export default class SpeedBinbHandler implements ResourceHandler {
     this.currentStateIndex += 1
 
     const process = async (page: Element, index: number) => {
-      const ptimg_url = this.get_ptimg_url(page.getAttribute('data-ptimg')!)
-      const resp = await getFromProxy(ptimg_url)
+      const ptimgUrl = this.getPtimgUrl(page.getAttribute('data-ptimg')!)
+      const resp = await getFromProxy(ptimgUrl)
       const body = await resp.json()
 
       assert(body, PageSchema)
@@ -70,8 +70,8 @@ export default class SpeedBinbHandler implements ResourceHandler {
 
       const img = new Image()
       img.crossOrigin = 'Anonymous'
-      const src_url = this.get_img_url(body.resources.i.src)
-      img.src = getProxiedUrl(src_url)
+      const srcUrl = this.getImgUrl(body.resources.i.src)
+      img.src = getProxiedUrl(srcUrl)
       await img.decode()
 
       const canvas = document.createElement('canvas')

--- a/src/resources/SpeedBinb.ts
+++ b/src/resources/SpeedBinb.ts
@@ -38,6 +38,14 @@ export default class SpeedBinbHandler implements ResourceHandler {
     this.zipFile = new JSZip()
   }
 
+  get_ptimg_url(ptimg_url: string): string {
+    return `${this.url.href}/${ptimg_url}`
+  }
+
+  get_img_url(src_url: string): string {
+    return `${this.url.href}/data/${src_url}`
+  }
+
   async execute(): Promise<JSZip> {
     const resp = await getFromProxy(this.url.href)
     const html = await resp.text()
@@ -52,7 +60,8 @@ export default class SpeedBinbHandler implements ResourceHandler {
     this.currentStateIndex += 1
 
     const process = async (page: Element, index: number) => {
-      const resp = await getFromProxy(`${this.url.href}/${page.getAttribute('data-ptimg')}`)
+      const ptimg_url = this.get_ptimg_url(page.getAttribute('data-ptimg')!)
+      const resp = await getFromProxy(ptimg_url)
       const body = await resp.json()
 
       assert(body, PageSchema)
@@ -61,7 +70,8 @@ export default class SpeedBinbHandler implements ResourceHandler {
 
       const img = new Image()
       img.crossOrigin = 'Anonymous'
-      img.src = getProxiedUrl(`${this.url.href}/data/${body.resources.i.src}`)
+      const src_url = this.get_img_url(body.resources.i.src)
+      img.src = getProxiedUrl(src_url)
       await img.decode()
 
       const canvas = document.createElement('canvas')

--- a/utils/generic.ts
+++ b/utils/generic.ts
@@ -19,6 +19,7 @@ import GanGanOnlineHandler from "~/src/resources/GanGanOnline";
 import CiaoShogakukanHandler from "~/src/resources/CiaoShogakukan";
 import PixivHandler from "~/src/resources/Pixiv";
 import PocketMagazineHandler from "~/src/resources/PocketMagazine";
+import KirapoHandler from "~/src/resources/Kirapo";
 
 export async function downloadZipFile(zipFile: JSZip) {
   const zipBlob = await zipFile.generateAsync({ type: 'blob' })
@@ -91,6 +92,8 @@ hostMap.set('comic-growl.com', GigaViewHandler)
 hostMap.set('storia.takeshobo.co.jp', SpeedBinbHandler)
 hostMap.set('ciao.shogakukan.co.jp', CiaoShogakukanHandler)
 hostMap.set('www.pixiv.net', PixivHandler)
+hostMap.set('www.pixiv.net', PixivHandler)
+hostMap.set('https://kirapo.jp/',KirapoHandler)
 export function mapUrlToHandler(url: string): typeof GigaViewHandler {
   const host = new URL(url).hostname
 

--- a/utils/generic.ts
+++ b/utils/generic.ts
@@ -93,7 +93,7 @@ hostMap.set('storia.takeshobo.co.jp', SpeedBinbHandler)
 hostMap.set('ciao.shogakukan.co.jp', CiaoShogakukanHandler)
 hostMap.set('www.pixiv.net', PixivHandler)
 hostMap.set('www.pixiv.net', PixivHandler)
-hostMap.set('https://kirapo.jp/',KirapoHandler)
+hostMap.set('kirapo.jp',KirapoHandler)
 export function mapUrlToHandler(url: string): typeof GigaViewHandler {
   const host = new URL(url).hostname
 


### PR DESCRIPTION
Comic Meteor and Comic Polaris both belong to FlexComix who recently consolidated all their websites into kirapo.jp
As such: removed comic-meteor and comic-polaris SpeedBinb handlers and replaced it with a Kirapo handler