### PR TITLE
fix: don't add content-type header if not exist

### DIFF
--- a/server/routes/proxy.ts
+++ b/server/routes/proxy.ts
@@ -49,9 +49,11 @@ export default defineEventHandler(async (event) => {
       ? await axios(combined, { responseType: 'stream', headers })
       : await axios.post(combined, new Uint8Array(body!), { responseType: 'stream', headers })
 
-    setHeaders(event, {
-      'Content-Type': stream.headers['content-type'],
-    })
+    if (stream.headers['content-type']) {
+      setHeaders(event, {
+        'Content-Type': stream.headers['content-type'],
+      })
+    }
     
     return sendStream(event, stream.data)
   } catch (error) {


### PR DESCRIPTION
this broke the comic fuz handler. they don't send content-type